### PR TITLE
[#61] [Backend] As a user I can list newsletters

### DIFF
--- a/remix/app/repositories/newsletter.server.test.ts
+++ b/remix/app/repositories/newsletter.server.test.ts
@@ -14,4 +14,16 @@ describe('Newsletter Repository', () => {
       ).resolves.toEqual(newsletter);
     });
   });
+
+  describe('findAll', () => {
+    it('returns all newsletters', async () => {
+      const newsletters = Array(5).fill(newsletterFactory);
+
+      prismaMock.newsletter.findMany.mockResolvedValue(newsletters);
+
+      await expect(NewsletterRepository.findMany({})).resolves.toEqual(
+        newsletters
+      );
+    });
+  });
 });

--- a/remix/app/repositories/newsletter.server.ts
+++ b/remix/app/repositories/newsletter.server.ts
@@ -6,6 +6,10 @@ class NewsletterRepository {
   static async create({ data }: Prisma.NewsletterCreateArgs) {
     return (await dbClient.newsletter.create({ data })) as Newsletter;
   }
+
+  static async findMany({ where }: Prisma.NewsletterFindManyArgs) {
+    return (await dbClient.newsletter.findMany({ where })) as Newsletter[];
+  }
 }
 
 export default NewsletterRepository;

--- a/remix/app/repositories/newsletter.server.ts
+++ b/remix/app/repositories/newsletter.server.ts
@@ -8,7 +8,10 @@ class NewsletterRepository {
   }
 
   static async findMany({ where }: Prisma.NewsletterFindManyArgs) {
-    return (await dbClient.newsletter.findMany({ where })) as Newsletter[];
+    return (await dbClient.newsletter.findMany({
+      where,
+      orderBy: { createAt: 'desc' },
+    })) as Newsletter[];
   }
 }
 

--- a/remix/app/routes/_app._index.test.tsx
+++ b/remix/app/routes/_app._index.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment node
+ */
+
+import { loader } from './_app._index';
+import { authenticator } from '../config/auth.server';
+import { prismaMock } from '../tests/database';
+import { newsletterFactory } from '../tests/factories/newsletter.factory';
+import { userFactory } from '../tests/factories/user.factory';
+
+jest.mock('../config/auth.server', () => ({
+  authenticator: {
+    isAuthenticated: jest.fn(),
+  },
+}));
+
+describe('Root Page', () => {
+  describe('loader', () => {
+    it('returns a list of newsletters', async () => {
+      const user = { ...userFactory };
+      const newsletters = Array(5).fill(newsletterFactory);
+
+      (authenticator.isAuthenticated as jest.Mock).mockResolvedValue(user);
+      prismaMock.newsletter.findMany.mockResolvedValue(newsletters);
+
+      const response = await loader();
+
+      expect(response).toEqual({ newsletters: newsletters });
+    });
+  });
+});

--- a/remix/app/routes/_app._index.test.tsx
+++ b/remix/app/routes/_app._index.test.tsx
@@ -7,6 +7,7 @@ import { authenticator } from '../config/auth.server';
 import { prismaMock } from '../tests/database';
 import { newsletterFactory } from '../tests/factories/newsletter.factory';
 import { userFactory } from '../tests/factories/user.factory';
+import { makeRequest } from '../tests/helpers/request';
 
 jest.mock('../config/auth.server', () => ({
   authenticator: {
@@ -17,13 +18,24 @@ jest.mock('../config/auth.server', () => ({
 describe('Root Page', () => {
   describe('loader', () => {
     it('returns a list of newsletters', async () => {
-      const user = { ...userFactory };
-      const newsletters = Array(5).fill(newsletterFactory);
+      const userAtttributes = { id: '1' };
+      const newsletterAttributes = { userId: '1' };
+
+      const user = { ...userFactory, ...userAtttributes };
+      const newsletter = { ...newsletterFactory, ...newsletterAttributes };
+
+      const newsletters = Array(5).fill(newsletter);
 
       (authenticator.isAuthenticated as jest.Mock).mockResolvedValue(user);
+      prismaMock.user.findUnique.mockResolvedValue(user);
       prismaMock.newsletter.findMany.mockResolvedValue(newsletters);
 
-      const response = await loader();
+      const request = makeRequest({
+        url: '/newsletter/create',
+        method: 'get',
+      });
+
+      const response = await loader({ request, params: {}, context: {} });
 
       expect(response).toEqual({ newsletters: newsletters });
     });

--- a/remix/app/routes/_app._index.test.tsx
+++ b/remix/app/routes/_app._index.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { loader } from './_app._index';
-import { authenticator } from '../config/auth.server';
+import appHandler from '../lib/handler/app.handler';
 import { prismaMock } from '../tests/database';
 import { newsletterFactory } from '../tests/factories/newsletter.factory';
 import { userFactory } from '../tests/factories/user.factory';
@@ -14,6 +14,8 @@ jest.mock('../config/auth.server', () => ({
     isAuthenticated: jest.fn(),
   },
 }));
+
+jest.mock('../lib/handler/app.handler');
 
 describe('Root Page', () => {
   describe('loader', () => {
@@ -26,8 +28,9 @@ describe('Root Page', () => {
 
       const newsletters = Array(5).fill(newsletter);
 
-      (authenticator.isAuthenticated as jest.Mock).mockResolvedValue(user);
-      prismaMock.user.findUnique.mockResolvedValue(user);
+      (appHandler as jest.Mock).mockImplementation((req, callback) =>
+        callback(user)
+      );
       prismaMock.newsletter.findMany.mockResolvedValue(newsletters);
 
       const request = makeRequest({

--- a/remix/app/routes/_app._index.tsx
+++ b/remix/app/routes/_app._index.tsx
@@ -1,17 +1,31 @@
-import { User } from '@prisma/client';
-import { useOutletContext } from '@remix-run/react';
+import { useLoaderData } from '@remix-run/react';
 
 import AppLink from '../components/AppLink';
+import NewsletterRepository from '../repositories/newsletter.server';
+
+export async function loader() {
+  const newsletters = await NewsletterRepository.findMany({});
+  return { newsletters };
+}
 
 export default function Index() {
-  const [user] = useOutletContext() as [User];
+  const { newsletters } = useLoaderData<typeof loader>();
 
   return (
-    <section>
-      <div className="flex justify-end">
-        <AppLink href="/newsletter/create" name={'Create Newsletter'} />
-      </div>
-      <h1>JS Framework Benchmark | {user?.name}</h1>
-    </section>
+    <>
+      <section>
+        <div className="flex justify-end">
+          <AppLink href="/newsletter/create" name={'Create Newsletter'} />
+        </div>
+        <ul>
+          {newsletters.map((newsletter) => (
+            <li key={newsletter.id}>
+              <h3>{newsletter.name}</h3>
+              <span>{newsletter.content}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </>
   );
 }

--- a/remix/app/routes/_app._index.tsx
+++ b/remix/app/routes/_app._index.tsx
@@ -1,16 +1,25 @@
+import { Newsletter } from '@prisma/client';
+import type { LoaderArgs } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
 
 import AppLink from '../components/AppLink';
+import appHandler from '../lib/handler/app.handler';
 import NewsletterRepository from '../repositories/newsletter.server';
 
-export async function loader() {
-  const newsletters = await NewsletterRepository.findMany({});
+export async function loader({ request }: LoaderArgs) {
+  return appHandler(request, async (session) => {
+    const newsletters = await NewsletterRepository.findMany({
+      where: { userId: session.id },
+    });
 
-  return { newsletters };
+    return { newsletters };
+  });
 }
 
 export default function Index() {
-  const { newsletters } = useLoaderData<typeof loader>();
+  const { newsletters } = useLoaderData<typeof loader>() as {
+    newsletters: Newsletter[];
+  };
 
   return (
     <>

--- a/remix/app/routes/_app._index.tsx
+++ b/remix/app/routes/_app._index.tsx
@@ -5,6 +5,7 @@ import NewsletterRepository from '../repositories/newsletter.server';
 
 export async function loader() {
   const newsletters = await NewsletterRepository.findMany({});
+
   return { newsletters };
 }
 


### PR DESCRIPTION
[#61]

## What happened 👀

- Implement a new method in `newsletter repository` to get the newsletters list `findMany`.
- Implement `loader` on the main page to load the newsletters list.
- Add testing.

## Insight 📝

In Remix, using `loader` is the way to load data into your component. As it acts like `GET` fetching data or `getServerSideProps` in `NextJS`, which will be active when the page load is on the server side.

#### Again here, no styling implemented yet (just plain HTML).
## Proof Of Work 📹
![Screenshot 2566-06-08 at 12 50 21](https://github.com/nimblehq/js-framework-benchmark/assets/59072804/f517fdf5-b45f-464c-bfe5-c4897ff65af3)